### PR TITLE
Use make manifest command to update MANIFEST

### DIFF
--- a/source/tutorial-english.html
+++ b/source/tutorial-english.html
@@ -2001,7 +2001,7 @@ shell> prove ./t/manifest.t
 </pre>
 By far better: the test points us to two files we for sure need to include in <code>MANIFEST</code> and precisely: <code>MANIFEST.SKIP</code> and <code>t/01-validate.t</code>
 
-Go to the <code>MANIFEST</code> file and add them (where they are appropriate, near similar files and paying attention to case an paths), then commit the change. If you rerun the above test you'll see files added to <code>MANIFEST</code> are no more present in the failure output.
+Use the <code>make manifest</code> command to add them automatically, then commit the change. If you rerun the above test you'll see files added to <code>MANIFEST</code> are no more present in the failure output.
 
 Let's examine the remaining two files. What is <code>ignore.txt</code>? It was created as default ignore list by <code>module-starter</code> and it contains many lines of regexes. If we want <code>module-starter</code> to create <code>MANIFEST.SKIP</code> instead, next time we'll use it specify <code>--ignores='manifest'</code> For the moment we can delete it. Commit.
 

--- a/source/tutorial-english.html
+++ b/source/tutorial-english.html
@@ -2001,7 +2001,7 @@ shell> prove ./t/manifest.t
 </pre>
 By far better: the test points us to two files we for sure need to include in <code>MANIFEST</code> and precisely: <code>MANIFEST.SKIP</code> and <code>t/01-validate.t</code>
 
-Use the <code>make manifest</code> command to add them automatically, then commit the change. If you rerun the above test you'll see files added to <code>MANIFEST</code> are no more present in the failure output.
+Use the <code>make manifest</code> command to add them automatically (after running <code>perl Makefile.PL</code> if necessary), then commit the change. If you rerun the above test you'll see files added to <code>MANIFEST</code> are no more present in the failure output.
 
 Let's examine the remaining two files. What is <code>ignore.txt</code>? It was created as default ignore list by <code>module-starter</code> and it contains many lines of regexes. If we want <code>module-starter</code> to create <code>MANIFEST.SKIP</code> instead, next time we'll use it specify <code>--ignores='manifest'</code> For the moment we can delete it. Commit.
 


### PR DESCRIPTION
The `make manifest` command is already designed to automatically add any missing files to MANIFEST, and is what MANIFEST.SKIP is really designed for. There's no need to add files to MANIFEST manually, only remove.