### PR TITLE
Mention make dist to create CPAN distribution tarball

### DIFF
--- a/source/tutorial-english.html
+++ b/source/tutorial-english.html
@@ -2120,7 +2120,7 @@ A good glance of two dozens of commits! We have done a good job, even if with so
 <a id="daysevenstep6"></a>
 <h4>step 6) try a real CPAN client installation</h4>
 
-It's now time to see if our module can be installaed by a cpan client. Nothing easier: if you are in the module folder just run <code>cpan .</code> and enjoy the output (note that this command will modify the content of the directory!).
+It's now time to see if our module can be installaed by a cpan client. Nothing easier: if you are in the distribution folder extracted from a tarball created by <code>make dist</code>, just run <code>cpan .</code> and enjoy the output (note that this command will modify the content of the directory!).
 
 
 

--- a/source/tutorial-english.html
+++ b/source/tutorial-english.html
@@ -1940,6 +1940,8 @@ As stated in "day zero - the plan" sharing early is a good principle: can be wor
 
 Your module is ready to be used and it is already used, but is not installable by a CPAN client nor can be indexed by a CPAN indexer at the moment. Read the short but complete description of possible files at <a href="https://www.perlmonks.org/index.pl?node_id=1009586">What are the files in a CPAN distribution?</a>
 
+To create a properly structured CPAN distribution you must run <code>perl Makefile.PL</code> then <code>make dist</code>, this will create a tarball in the current directory that you can share and install using a CPAN client, or even upload to CPAN.
+
 Following tests are not needed to install or use your module but to help you spotting what can be wrong in your distribution.
 
 


### PR DESCRIPTION
`make dist` must be used to create a proper CPAN tarball before any sharing or installing of the code is attempted. This notably includes generating META.yml/META.json and adding them to MANIFEST, and leaving out any files not in MANIFEST.